### PR TITLE
SYN packet with payload

### DIFF
--- a/bpftools/__init__.py
+++ b/bpftools/__init__.py
@@ -7,12 +7,14 @@ from . import gen_dns_validate
 from . import gen_suffix
 from . import utils
 from . import gen_dns_badrand
+from . import gen_tcpsyn_data
 
 name_to_gen = {
     'dns': gen_dns.gen,
     'dns_validate': gen_dns_validate.gen,
     'suffix': gen_suffix.gen,
     'dns_badrand': gen_dns_badrand.gen,
+    'tcpsyn_data': gen_tcpsyn_data.gen,
     }
 
 generator_names = name_to_gen.keys()

--- a/bpftools/__init__.py
+++ b/bpftools/__init__.py
@@ -6,6 +6,7 @@ from . import gen_dns
 from . import gen_dns_validate
 from . import gen_suffix
 from . import utils
+from . import gen_badrand
 from . import gen_tcpsyn_data
 
 name_to_gen = {

--- a/bpftools/gen_badrand.py
+++ b/bpftools/gen_badrand.py
@@ -17,21 +17,24 @@ what is detected by this BPF rule.
 
 
     if ipversion == 4:
-        print "ldx 4*([%i]&0xf)" % (l3_off)     # IHL value
-        print "ldb [x + %i]" % (l3_off + 1)     # Loading TCP/UDP byte 1 port into A
-        print "lsh #8"                          # Bit shifting
-        print "st M[%i]" % (0)                  # Storing A into M[0]
-        print "ldb [x + %i]" % (l3_off)         # Loading TCP/UDP byte 0 port into A
-        print "ldx M[%i]" % (0)                 # Loading M[0] (UDP port shifted byte 1) into X
-        print "or x"                            # Oring A and X
-        print "tax"
+        print "    ldx 4*([%i]&0xf)" % (l3_off)     # IHL value
+        print "    ldb [x + %i]" % (l3_off + 1)     # Loading TCP/UDP byte 1 port into A
+        print "    lsh #8"                          # Bit shifting
+        print "    st M[%i]" % (0)                  # Storing A into M[0]
+        print "    ldb [x + %i]" % (l3_off)         # Loading TCP/UDP byte 0 port into A
+        print "    ldx M[%i]" % (0)                 # Loading M[0] (UDP port shifted byte 1) into X
+        print "    ; A holds the byte 0 of the TCP/UDP port and X the byte 1"
+        print "    or x"                            # Oring A and X
+        print "    ; ORing these values into X"
+        print "    tax"
 
-        print "ldh [%i]" % (l3_off + 4)         # Loading IP identifier into A
-        print "xor x"                           # Xoring A and X (Port and IP ID)
-        print "jeq #0x0, match"
-        print "ret #%i" % (0 if not negate else 1)
-        print "match:"
-        print "ret #%i" % (1 if not negate else 0)
+        print "    ldh [%i]" % (l3_off + 4)         # Loading IP identifier into A
+        print "    ; Loading IP ID into A and XORing A with X"
+        print "    xor x"                           # Xoring A and X (Port and IP ID)
+        print "    ; If the result is equal to 0 it means IP ID is equal to the byte swaped port"
+        print "    jeq #0x0, match"
+        print "    ret #%i" % (0 if not negate else 1)
+        print "    match:"
+        print "    ret #%i" % (1 if not negate else 0)
 
     return ''
-

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -8,47 +8,55 @@ def gen(params, l3_off=0, ipversion=4, negate=False):
         prog="%s tcpsyn_data --" % (sys.argv[0]),
         description=r'''
 
-Ble
+Generate raw BPF rules matching SYN packets with a payload.
+It works on both IPV6 and IPV4. IPV6 extension headers are not supported.
+This rule returns match if the packet is SYN only and has a IP total length field
+which is bigger than IP header length added to the TCP header length.
+
+If this bigger that means there are some data -> this matches SYN packet with data.
+It does not match all the other packets.
+
+IPV4 successfully manually tested on 25 packets.
 
 ''')
-
+    
     if ipversion == 6:
         frame_size_off = 4
         protocol_value_off = 6
-        print "ldx #40"      # No extension header support
+        print "ldx #40"  				# No extension header support
 
     if ipversion == 4:
         frame_size_off = 2
         protocol_value_off = 9
-        print "ldx 4*([%i]&0xf)" % (l3_off)  # IHL value in X
+        print "ldx 4*([%i]&0xf)" % (l3_off)  		# IHL value in X
 
-    print "ldh [%i]" % (l3_off + frame_size_off)      # Global frame size in m[1]
+    print "ldh [%i]" % (l3_off + frame_size_off)	# Global frame size in m[1]
     print "st M[1]" 
-    print "ldb [%i]" % (l3_off + protocol_value_off)      # Protocol value in A
+    print "ldb [%i]" % (l3_off + protocol_value_off)	# Protocol value in A
 
-    print "jneq #0x06, nonmatch" #0x06 is TCP protocol in IPV4/IPV6
+    print "jneq #0x06, nonmatch" 			#0x06 is TCP protocol in IPV4/IPV6
 
     # The following code is TCP related
 
     print "ldb [x + %i]" % (l3_off + 13)
-    print "and #0x12" #00010010 : only ACK and SYN bits matter
+    print "and #0x12" 					#00010010 : only ACK and SYN bits matter
     # Total frame length - IP header length = TCP data offset
 
-    print "jneq #0x2, nonmatch" #Error if value is 0 or 00010000 or 00010010 
+    print "jneq #0x2, nonmatch" 			# We do not match packets if value is 0 or 00010000 or 00010010 
     
     print "ld M[1]" 
-    print "sub x"    #result in A
-    print "st M[3]" #result in M[3]
+    print "sub x"    					# Result in A
+    print "st M[3]"  					# Result in M[3]
     
     print "ldb [x + %i]" % (l3_off + 12)
-    print "rsh #0x4" # The TCP header size is stored on the 4 MSB...
-    print "mul #0x4" # ...value which is stored in 32bits words... need the value in bytes in A
+    print "rsh #0x4"  					# The TCP header size is stored on the 4 MSB...
+    print "mul #0x4"  					# ...value which is stored in 32bits words... need the value in bytes in A
     
     #We do not need the value stored in X anymore can use it
     print "ldx M[3]"
 
-    print "sub x" #Should be 0
-    print "jneq #0x0, nonmatch"
+    print "sub x" 					#Should be 0
+    print "jeq #0x0, nonmatch" #If is 0 it does not match, the packet is valid
 
     print "match:"
     print "ret #%i" % (1 if not negate else 0)

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -13,16 +13,18 @@ Ble
 ''')
 
     if ipversion == 6:
-        print "jmp nonmatch"
-        # for both ipv4 et ipv6 jai besoin de taille header IP et taille globale...
-        # loader ca dns m[0] et m[1]
-        # et de verifier que cest bien du TCP
-        
+        frame_size_off = 4
+        protocol_value_off = 6
+        print "ldx #40"      # No extension header support
+
     if ipversion == 4:
+        frame_size_off = 2
+        protocol_value_off = 9
         print "ldx 4*([%i]&0xf)" % (l3_off)  # IHL value in X
-        print "ldh [%i]" % (l3_off + 2)      # Global frame size in m[1]
-        print "st M[%i]" % (1)
-        print "ldb [%i]" % (l3_off + 9)      # Protocol value in A
+
+    print "ldh [%i]" % (l3_off + frame_size_off)      # Global frame size in m[1]
+    print "st M[1]" 
+    print "ldb [%i]" % (l3_off + protocol_value_off)      # Protocol value in A
 
     print "jneq #0x06, nonmatch" #0x06 is TCP protocol in IPV4/IPV6
 
@@ -34,16 +36,16 @@ Ble
 
     print "jneq #0x2, nonmatch" #Error if value is 0 or 00010000 or 00010010 
     
-    print "ld M[%i]" % (1)
-    print "sub x" #result in A
-    print "st M[%i]" % (3) #result in M[3]
+    print "ld M[1]" 
+    print "sub x"    #result in A
+    print "st M[3]" #result in M[3]
     
     print "ldb [x + %i]" % (l3_off + 12)
     print "rsh #0x4" # The TCP header size is stored on the 4 MSB...
     print "mul #0x4" # ...value which is stored in 32bits words... need the value in bytes in A
     
     #We do not need the value stored in X anymore can use it
-    print "ldx M[%i]" % (3)
+    print "ldx M[3]"
 
     print "sub x" #Should be 0
     print "jneq #0x0, nonmatch"

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -1,0 +1,59 @@
+import argparse
+import string
+import sys
+
+def gen(params, l3_off=0, ipversion=4, negate=False):
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        prog="%s tcpsyn_data --" % (sys.argv[0]),
+        description=r'''
+
+Ble
+
+''')
+
+    if ipversion == 6:
+        print "jmp nonmatch"
+        # for both ipv4 et ipv6 jai besoin de taille header IP et taille globale...
+        # loader ca dns m[0] et m[1]
+        # et de verifier que cest bien du TCP
+        
+    if ipversion == 4:
+        print "ldx 4*([%i]&0xf)" % (l3_off)  # IHL value in X
+        print "ldh [%i]" % (l3_off + 2)      # Global frame size in m[1]
+        print "st M[%i]" % (1)
+        print "ldb [%i]" % (l3_off + 9)      # Protocol value in A
+
+    print "jneq #0x06, nonmatch" #0x06 is TCP protocol in IPV4/IPV6
+
+    # The following code is TCP related
+
+    print "ldb [x + %i]" % (l3_off + 13)
+    print "and #0x12" #00010010 : only ACK and SYN bits matter
+    # Total frame length - IP header length = TCP data offset
+
+    print "jeq #0x12, nonmatch" #Error if value is 00010010 (ACK + SYN)
+    print "jneq #0x2, nonmatch" #Error if value is 0 or 00010000 and accept if 10
+    
+    print "ld M[%i]" % (1)
+    print "sub x" #result in A
+    print "st M[%i]" % (3) #result in M[3]
+    
+    print "ldb [x + %i]" % (l3_off + 12)
+    print "rsh #0x4" # The TCP header size is stored on the 4 MSB...
+    print "mul #0x4" # ...value which is stored in 32bits words... need the value in bytes in A
+    
+    #We do not need the value stored in X anymore can use it
+    print "ldx M[%i]" % (3)
+
+    print "sub x" #Should be 0
+    print "jneq #0x0, nonmatch"
+
+    print "match:"
+    print "ret #%i" % (1 if not negate else 0)
+
+    print "nonmatch:"
+    print "ret #%i" % (0 if not negate else 1)
+
+    return ''
+

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -32,8 +32,7 @@ Ble
     print "and #0x12" #00010010 : only ACK and SYN bits matter
     # Total frame length - IP header length = TCP data offset
 
-    print "jeq #0x12, nonmatch" #Error if value is 00010010 (ACK + SYN)
-    print "jneq #0x2, nonmatch" #Error if value is 0 or 00010000 and accept if 10
+    print "jneq #0x2, nonmatch" #Error if value is 0 or 00010000 or 00010010 
     
     print "ld M[%i]" % (1)
     print "sub x" #result in A

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -16,53 +16,53 @@ which is bigger than IP header length added to the TCP header length.
 If this bigger that means there are some data -> this matches SYN packet with data.
 It does not match all the other packets.
 
-IPV4 successfully manually tested on 25 packets.
+SYN must be set and ACK must be clear.
 
 ''')
     
     if ipversion == 6:
         frame_size_off = 4
         protocol_value_off = 6
-        print "ldx #40"  				# No extension header support
+        print "    ldx #40"  				# No extension header support
 
     if ipversion == 4:
         frame_size_off = 2
         protocol_value_off = 9
-        print "ldx 4*([%i]&0xf)" % (l3_off)  		# IHL value in X
+	print "    ldx 4*([%i]&0xf)" % (l3_off)  	# IHL value in X
 
-    print "ldh [%i]" % (l3_off + frame_size_off)	# Global frame size in m[1]
-    print "st M[1]" 
-    print "ldb [%i]" % (l3_off + protocol_value_off)	# Protocol value in A
+    print "    ldh [%i]" % (l3_off + frame_size_off)	# Global frame size in m[1]
+    print "    st M[1]" 
+    print "    ldb [%i]" % (l3_off + protocol_value_off)# Protocol value in A
 
-    print "jneq #0x06, nonmatch" 			#0x06 is TCP protocol in IPV4/IPV6
+    print "    jneq #0x06, nonmatch" 			# 0x06 is TCP protocol in IPV4/IPV6
 
     # The following code is TCP related
 
-    print "ldb [x + %i]" % (l3_off + 13)
-    print "and #0x12" 					#00010010 : only ACK and SYN bits matter
+    print "    ldb [x + %i]" % (l3_off + 13)
+    print "    and #0x12" 				# 00010010 : only ACK and SYN bits matter
     # Total frame length - IP header length = TCP data offset
 
-    print "jneq #0x2, nonmatch" 			# We do not match packets if value is 0 or 00010000 or 00010010 
+    print "    jneq #0x2, nonmatch" 			# We do not match packets if value is 0 or 00010000 or 00010010 
     
-    print "ld M[1]" 
-    print "sub x"    					# Result in A
-    print "st M[3]"  					# Result in M[3]
+    print "    ld M[1]" 				# Global frame size
+    print "    sub x"    				# Result in A
+    print "    st M[3]"  				# Result in M[3]
     
-    print "ldb [x + %i]" % (l3_off + 12)
-    print "rsh #0x4"  					# The TCP header size is stored on the 4 MSB...
-    print "mul #0x4"  					# ...value which is stored in 32bits words... need the value in bytes in A
+    print "    ldb [x + %i]" % (l3_off + 12)            # Loading the byte containing the TCP Header size...
+    print "    rsh #0x4"  				# ...the TCP header size is stored on the 4 MSB...
+    print "    mul #0x4"  				# ...value which is stored in 32bits words... need the value in bytes in A
     
     #We do not need the value stored in X anymore can use it
-    print "ldx M[3]"
+    print "    ldx M[3]"
 
-    print "sub x" 					#Should be 0
-    print "jeq #0x0, nonmatch" #If is 0 it does not match, the packet is valid
+    print "    sub x" 					# Should be 0
+    print "    jeq #0x0, nonmatch" 			# If is 0 it does not match, the packet is valid
 
-    print "match:"
-    print "ret #%i" % (1 if not negate else 0)
+    print "    match:"
+    print "    ret #%i" % (1 if not negate else 0)
 
-    print "nonmatch:"
-    print "ret #%i" % (0 if not negate else 1)
+    print "    nonmatch:"
+    print "    ret #%i" % (0 if not negate else 1)
 
     return ''
 


### PR DESCRIPTION
This BPF generator matches SYN packets which have a payload.
SYN + ACK packets does not match.
SYN packets without a payload does not match.

Manually tested on 25 ipv4 packets at the moment. Both positives and negatives.
ipv6 packets support has not been tested yet.


