### PR TITLE
Set proper return value on match

### DIFF
--- a/bpftools/gen_badrand.py
+++ b/bpftools/gen_badrand.py
@@ -38,12 +38,12 @@ what is detected by this BPF rule.
         print "    sub x"
         print "    ; If the result is equal to 0 it means IP ID is equal to the byte swaped port"
         print "    jeq #0x0, match"
-        print "    ret #%i" % (0 if not negate else 1,)
+        print "    ret #%i" % (0 if not negate else 65535,)
         print "match:"
-        print "    ret #%i" % (1 if not negate else 0,)
+        print "    ret #%i" % (65535 if not negate else 0,)
 
     if ipversion == 6:
         print "    ; ipv6 not supported, no ipid. Never match"
-        print "    ret #%i" % (0 if not negate else 1,)
+        print "    ret #%i" % (0 if not negate else 65535,)
 
     return ''

--- a/bpftools/gen_dns.py
+++ b/bpftools/gen_dns.py
@@ -253,11 +253,11 @@ supported.
                 match_exact(rule, label, last)
             else:
                 match_star(rule, label)
-        print "    ret #%i" % (1 if not negate else 0)
+        print "    ret #%i" % (65535 if not negate else 0)
         print
 
     print "lb_%i:" % (i+1,)
-    print "    ret #%i" % (0 if not negate else 1)
+    print "    ret #%i" % (0 if not negate else 65535)
 
     name_parts = []
     for domain in args.domains:

--- a/bpftools/gen_dns_validate.py
+++ b/bpftools/gen_dns_validate.py
@@ -84,10 +84,10 @@ are clear supply "--strict" flag.
     print "    jneq #0x0, match"
     print "    ldh [x + 10]       ; arcount must be 0 or 1"
     print "    jgt #0x1, match"
-    print "    ret #%i" % (0 if not negate else 1)
+    print "    ret #%i" % (0 if not negate else 65535)
     print
     print "match:"
-    print "    ret #%i" % (1 if not negate else 0)
+    print "    ret #%i" % (65535 if not negate else 0)
 
     if args.strict:
         return 'strict'

--- a/bpftools/gen_suffix.py
+++ b/bpftools/gen_suffix.py
@@ -63,9 +63,9 @@ This is the same as:
             print "    ldb [x + %i]" % off
             print "    jneq #0x%02x, nomatch" % (m, )
             off += 1
-    print "    ret #%i" % (1 if not negate else 0)
+    print "    ret #%i" % (65535 if not negate else 0)
     print ""
     print "nomatch:"
-    print "    ret #%i" % (0 if not negate else 1)
+    print "    ret #%i" % (0 if not negate else 65535)
 
     return suffix_hex

--- a/bpftools/gen_tcpsyn_data.py
+++ b/bpftools/gen_tcpsyn_data.py
@@ -72,10 +72,10 @@ SYN must be set and ACK must be clear. Other flags are ignored.
     print "    jeq #0x0, nonmatch" 			# If is 0 it does not match, the packet is valid
 
     print "match:"
-    print "    ret #%i" % (1 if not negate else 0)
+    print "    ret #%i" % (65535 if not negate else 0)
 
     print "nonmatch:"
-    print "    ret #%i" % (0 if not negate else 1)
+    print "    ret #%i" % (0 if not negate else 65535)
 
     return ''
 


### PR DESCRIPTION
The return value is meant to be the size of the packet that has been matched,
not a boolean value and returning 1 could cause packet truncation.

Set the return value to 65535 on match instead, since it ought to be big
enough to match a whole packet.

Fixes #11 

---

There's probably a better way to do this, to avoid code duplication, but this is enough for now.