### PR TITLE
FreeBSD compatibility

### DIFF
--- a/bpftong
+++ b/bpftong
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+"""
+script to convert the compiled output from bpf_asm
+into a format compatible with FreeBSD's ng_bpf
+"""
+
+import sys
+
+def insn(x):
+  return "{ code=%s jt=%s jf=%s k=%s }" % tuple(x.split(' '))
+
+bpf = "".join(sys.stdin).split(',')
+
+len = int(bpf[0])
+prog = " ".join(map(insn, bpf[1:len + 1]))
+print "bpf_prog_len=%d bpf_prog=[%s]" % (len, prog)

--- a/linux_tools/Makefile
+++ b/linux_tools/Makefile
@@ -8,9 +8,16 @@ YACC = bison
 	$(YACC) -o $@ -d $<
 
 %.lex.c: %.l
-	$(LEX) -o $@ $<
+	$(LEX) -o$@ $<
 
-all : bpf_jit_disasm bpf_dbg bpf_asm
+TARGETS = bpf_asm
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	TARGETS += bpf_jit_asm bpf_dbg
+endif
+
+all : $(TARGETS)
 
 bpf_jit_disasm : CFLAGS = -Wall -O2 -DPACKAGE='bpf_jit_disasm' -I.
 bpf_jit_disasm : LDLIBS = -lopcodes -lbfd -ldl


### PR DESCRIPTION
The attached patches include changes to the `linux_tools/` directory sufficient to make `bpf_asm` compile (but produce runtime errors if Linux-specific BPF extensions are used).

There's also a script named `bpftong` to create FreeBSD netgraph `ng_bpf` format programs from `bpf_asm` output.