### PR TITLE
Fix awk assignment instead of comparisson

### DIFF
--- a/iptables_bpf
+++ b/iptables_bpf
@@ -39,7 +39,7 @@ set -o pipefail
 : ${IPTABLES:="%(iptables)s"}
 : ${IPSET:="ipset"}
 : ${INPUTPLACE:="1"}
-: ${DEFAULTINT:=`awk 'BEGIN {n=0} $2 == "00000000" {n=1; print $1; exit} END {if (n=0) {print "eth0"}}' /proc/net/route`}
+: ${DEFAULTINT:=`awk 'BEGIN {n=0} $2 == "00000000" {n=1; print $1; exit} END {if (n==0) {print "eth0"}}' /proc/net/route`}
 
 iptablesrule () {
     ${IPTABLES} \

--- a/iptables_bpf_chain
+++ b/iptables_bpf_chain
@@ -28,7 +28,7 @@ set -o pipefail
 : ${IPTABLES:="%(iptables)s"}
 : ${IPSET:="ipset"}
 : ${INPUTPLACE:="1"}
-: ${DEFAULTINT:=`awk 'BEGIN {n=0} $2 == "00000000" {n=1; print $1; exit} END {if (n=0) {print "eth0"}}' /proc/net/route`}
+: ${DEFAULTINT:=`awk 'BEGIN {n=0} $2 == "00000000" {n=1; print $1; exit} END {if (n==0) {print "eth0"}}' /proc/net/route`}
 
 main_match () {
     ${IPTABLES} \


### PR DESCRIPTION
`if (n=0)` is always 'falsey' since assignment results to the value being assigned (in case of 0 that would be 0, which in awk is considered 'falsey')
```
~/git/cloudflare/bpftools$ awk 'BEGIN { if (n=0) print (n=0) }'
~/git/cloudflare/bpftools$ awk 'BEGIN { if (n=1) print (n=1) }'
1
~/git/cloudflare/bpftools$ awk 'BEGIN { if (n=2) print (n=2) }'
2
```