### PR TITLE
Fix p0f ittl

### DIFF
--- a/bpftools/p0f.py
+++ b/bpftools/p0f.py
@@ -52,6 +52,8 @@ class P0fBPF:
         if self.ittl.endswith("-"):
             self.ttl_rand = True
         else:
+            if "+" in self.ittl:
+                self.ittl, _ = self.ittl.split("+")
             self.ttl_rand = False
 
     def parse_win_size(self):
@@ -78,7 +80,7 @@ class P0fBPF:
         if self.ver != '4' and self.ver != '6':
             raise ValueError("IP version must be either 4 or 6")
 
-        if not re.match("^(\d+)-?$", self.ittl):
+        if not re.match("^(\d+)(-|\+\d+)?$", self.ittl):
             raise ValueError("Invalid ttl field")
         self.parse_ittl()
 

--- a/bpftools/p0f.py
+++ b/bpftools/p0f.py
@@ -80,7 +80,7 @@ class P0fBPF:
         if self.ver != '4' and self.ver != '6':
             raise ValueError("IP version must be either 4 or 6")
 
-        if not re.match("^(\d+)(-|\+\d+)?$", self.ittl):
+        if not re.match("^(\d+)(-|\+\d+|\+\?)?$", self.ittl):
             raise ValueError("Invalid ttl field")
         self.parse_ittl()
 


### PR DESCRIPTION
https://github.com/p0f/p0f/blob/4abbd20ecd7421461e360c77a98dff98e08a8b10/docs/README#L526-L539

According to the readme of p0f, the value of `ittl` can be in the following formats:

```
\d+
\d+-
\d+\d+
\d+?
```

Currently the script is working for the first two, but throws an error for the other.